### PR TITLE
Add filter replacement sensor

### DIFF
--- a/custom_components/ecostream/sensor.py
+++ b/custom_components/ecostream/sensor.py
@@ -34,6 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     await coordinator.async_config_entry_first_refresh()
 
     sensors = [
+        EcostreamFilterReplacementWarningSensor(coordinator, entry),
         EcostreamFrostProtectionSensor(coordinator, entry),
         EcostreamQsetSensor(coordinator, entry),
         EcostreamModeTimeLeftSensor(coordinator, entry),
@@ -108,6 +109,28 @@ class EcostreamFrostProtectionSensor(EcostreamSensorBase):
     def icon(self):
         """Return the icon to use in the frontend, if any."""
         return "mdi:snowflake-melt"
+
+class EcostreamFilterReplacementWarningSensor(EcostreamSensorBase):
+    """Sensor for the filter replacement warning."""
+
+    @property
+    def unique_id(self):
+        return f"{self._entry_id}_filter_replacement_warning"
+
+    @property
+    def name(self):
+        return "Ecostream Filter Replacement"
+
+    @property
+    def state(self):
+        errors = self.coordinator.data.get("status", {}).get("errors", [])
+
+        return any(error["type"] == "ERROR_FILTER" for error in errors)
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:air-filter"
 
 class EcostreamQsetSensor(EcostreamSensorBase):
     """Sensor for Qset status."""


### PR DESCRIPTION
First of all thanks for putting this integration together! Given that I can control the fans through home assistant, I missed the warning in the app that the filtered had to be replaced. Would be great to have the same information in the home assistant integration.

**Example response from my BUVA ecostream:**
```
{
   "status":{
      "connect_status":1,
      "errors":[
         {
            "type":"ERROR_SENSOR",
            "code":2,
            "data":32,
            "message":"No CCS811 Sensor detected on address 0x5A",
            "time":1314
         },
         {
            "type":"ERROR_FILTER",
            "code":1,
            "data":0,
            "message":"Filters need replacing",
            "time":120484
         }
      ],
      "bypass_pos":0.000000,
      "qset":180.000000,
      "override_set_time_left":801,
      "override_bypass_time_left":0,
      "override_balance_time_left":0,
      "fan_eha_speed":1279.680786,
      "fan_sup_speed":1305.446777,
      "frost_protection":false,
      "sensor_eco2_eta":0.000000,
      "sensor_rh_eta":47.685207,
      "sensor_temp_eha":8.142498,
      "sensor_temp_eta":18.573259,
      "sensor_temp_oda":4.730293,
      "sensor_tvoc_eta":0.000000,
      "sensor_ext_co2":0.000000
   }
}
```

<img width="367" alt="Screenshot 2025-02-11 at 12 38 11" src="https://github.com/user-attachments/assets/61a808d3-1ae5-4a5b-afe7-5e00e4ae9228" />
