### PR TITLE
Add filter replacement reset

### DIFF
--- a/custom_components/ecostream/__init__.py
+++ b/custom_components/ecostream/__init__.py
@@ -20,6 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.FAN,
+    Platform.BUTTON
 ]
 
 class EcostreamWebsocketsAPI:

--- a/custom_components/ecostream/button.py
+++ b/custom_components/ecostream/button.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+from dateutil.relativedelta import relativedelta
+from homeassistant.util import dt
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.config_entries import ConfigEntry # type: ignore
+from homeassistant.core import HomeAssistant # type: ignore
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity # type: ignore
+from homeassistant.const import UnitOfTime # type: ignore
+
+from . import EcostreamDataUpdateCoordinator, EcostreamWebsocketsAPI
+from .const import DOMAIN
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry[EcostreamDataUpdateCoordinator],
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the button platform."""
+    coordinator = entry.runtime_data
+    
+    buttons = [
+        FilterResetButton(coordinator, entry)
+    ]
+
+    # Add your button entity
+    async_add_entities(buttons)
+
+class EcostreamButtonBase(CoordinatorEntity, ButtonEntity):
+    """Base class for ecostream buttons."""
+    def __init__(self, coordinator: EcostreamDataUpdateCoordinator, entry: ConfigEntry):
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._entry_id = entry.entry_id
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.api._host)},
+            name="EcoStream",
+            manufacturer="Buva",
+            model="EcoStream",
+        )
+
+class FilterResetButton(EcostreamButtonBase):
+    """Button that resets the filter replacement date."""
+
+    def __init__(self, coordinator: EcostreamDataUpdateCoordinator, entry: ConfigEntry):
+        """Initialize the button"""
+        super().__init__(coordinator, entry)
+        self._last_pressed = None
+
+    @property
+    def unique_id(self):
+        return f"{self._entry_id}_reset_filter"
+
+    @property
+    def name(self):
+        return "Ecostream Reset Filter"
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:air-filter"
+
+    @property
+    def extra_state_attributes(self):
+        """Return additional state attributes."""
+        return {
+            "last_pressed": self._last_pressed
+        }
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        
+        # Get current date and time
+        now = dt.utcnow()
+        self._last_pressed = now
+
+        # Add 3 months (which seems to correspond with what the ecostream app does)
+        nextReplacementDate = now + relativedelta(months=3)
+        nextReplacementTimestamp = int(nextReplacementDate.timestamp())
+
+        # Send the new filter replacement date to the unit
+        payload = {
+            "config": {
+                "filter_datetime": nextReplacementTimestamp
+            }
+        }
+        await self.coordinator.api.send_json(payload)

--- a/custom_components/ecostream/manifest.json
+++ b/custom_components/ecostream/manifest.json
@@ -6,7 +6,7 @@
    ],
    "config_flow": true,
    "dependencies": [],
-   "documentation": "https://www.home-assistant.io/integrations/ecostream",
+   "documentation": "https://github.com/epodegrid/ecostream_homeassistant_integration",
    "homekit": {},
    "iot_class": "local_push",
    "issue_tracker": "https://github.com/epodegrid/ecostream_homeassistant_integration/issues",


### PR DESCRIPTION
Why are we changing this?
To add more information about the filters and give to option to reset the date when the filters have been replaced

What has changed?
- A sensor was added that displays the next date the filters should be replaced
- A button was added to reset the filter replacement date, the date gets set to 3 months in the future. This seems to be what the original app from Buva does as well.

![image](https://github.com/user-attachments/assets/97f3a6de-47b0-4c57-ba51-023b8bf17b4d)

![image](https://github.com/user-attachments/assets/781b9b9a-2687-4736-9cb3-249035e139a7)
