### PR TITLE
Add icons for presets

### DIFF
--- a/custom_components/ecostream/fan.py
+++ b/custom_components/ecostream/fan.py
@@ -21,9 +21,9 @@ from homeassistant.util.percentage import (
 from . import EcostreamDataUpdateCoordinator, EcostreamWebsocketsAPI
 from .const import DOMAIN
 
-PRESET_MODE_LOW = "Low"
-PRESET_MODE_MID = "Medium"
-PRESET_MODE_HIGH = "High"
+PRESET_MODE_LOW = "low"
+PRESET_MODE_MID = "mid"
+PRESET_MODE_HIGH = "high"
 
 async def async_setup_entry(
     hass: HomeAssistant, 

--- a/custom_components/ecostream/fan.py
+++ b/custom_components/ecostream/fan.py
@@ -21,9 +21,9 @@ from homeassistant.util.percentage import (
 from . import EcostreamDataUpdateCoordinator, EcostreamWebsocketsAPI
 from .const import DOMAIN
 
-PRESET_MODE_LOW = "low"
-PRESET_MODE_MID = "mid"
-PRESET_MODE_HIGH = "high"
+PRESET_MODE_LOW = "Low"
+PRESET_MODE_MID = "Medium"
+PRESET_MODE_HIGH = "High"
 
 async def async_setup_entry(
     hass: HomeAssistant, 
@@ -52,6 +52,8 @@ class EcoStreamFan(CoordinatorEntity, FanEntity):
         PRESET_MODE_HIGH,
     ]
     
+    _attr_translation_key = "ecostream_fan"
+
     current_speed: float | None = None
 
     def __init__(self, coordinator: EcostreamDataUpdateCoordinator, entry: ConfigEntry):

--- a/custom_components/ecostream/icons.json
+++ b/custom_components/ecostream/icons.json
@@ -7,7 +7,7 @@
             "default": "mdi:fan",
             "state": {
               "low": "mdi:fan-speed-1",
-              "medium": "mdi:fan-speed-2",
+              "mid": "mdi:fan-speed-2",
               "high": "mdi:fan-speed-3"
             }
           }

--- a/custom_components/ecostream/icons.json
+++ b/custom_components/ecostream/icons.json
@@ -6,9 +6,9 @@
           "preset_mode": {
             "default": "mdi:fan",
             "state": {
-              "Low": "mdi:fan-speed-1",
-              "Medium": "mdi:fan-speed-2",
-              "High": "mdi:fan-speed-3"
+              "low": "mdi:fan-speed-1",
+              "medium": "mdi:fan-speed-2",
+              "high": "mdi:fan-speed-3"
             }
           }
         }

--- a/custom_components/ecostream/icons.json
+++ b/custom_components/ecostream/icons.json
@@ -1,0 +1,18 @@
+{
+  "entity": {
+    "fan": {
+      "ecostream_fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:fan",
+            "state": {
+              "Low": "mdi:fan-speed-1",
+              "Medium": "mdi:fan-speed-2",
+              "High": "mdi:fan-speed-3"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/ecostream/sensor.py
+++ b/custom_components/ecostream/sensor.py
@@ -383,4 +383,4 @@ class EcostreamRhEtaSensor(EcostreamSensorBase):
     @property
     def icon(self):
         """Return the icon to use in the frontend, if any."""
-        return "mdi:molecule-co2"
+        return "mdi:water-percent"

--- a/custom_components/ecostream/translations/en.json
+++ b/custom_components/ecostream/translations/en.json
@@ -15,5 +15,20 @@
                 }
             }
         }
+    },
+    "entity": {
+    "fan": {
+      "ecostream_fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "low": "Low",
+              "mid": "Medium",
+              "high": "High"
+            }
+          }
+        }
+      }
     }
+  }
 }


### PR DESCRIPTION
In this PR I added icons for the presets and fixed the icon for the Relative Humidity Return sensor.

The presets dropdown now looks like this
![image](https://github.com/user-attachments/assets/b9d0ced0-56be-4e11-af22-00d1a0500a2a)
And when using a tile card with the presets feature it looks like this
![image](https://github.com/user-attachments/assets/181a7d39-76f4-41f7-a65b-701c8863e253)
