### PR TITLE
Add wifi diagnostics

### DIFF
--- a/custom_components/ecostream/fan.py
+++ b/custom_components/ecostream/fan.py
@@ -62,14 +62,14 @@ class EcoStreamFan(CoordinatorEntity, FanEntity):
         self.current_speed = self.coordinator.data.get("status", {}).get("qset")
 
         self._speed_range = (
-            self.coordinator.api._config["capacity_min"], 
-            self.coordinator.api._config["capacity_max"],
+            self.coordinator.api._data["config"]["capacity_min"], 
+            self.coordinator.api._data["config"]["capacity_max"],
         )
 
         self._preset_speeds = {
-            PRESET_MODE_LOW: self.coordinator.api._config["setpoint_low"],
-            PRESET_MODE_MID: self.coordinator.api._config["setpoint_mid"],
-            PRESET_MODE_HIGH: self.coordinator.api._config["setpoint_high"],
+            PRESET_MODE_LOW: self.coordinator.api._data["config"]["setpoint_low"],
+            PRESET_MODE_MID: self.coordinator.api._data["config"]["setpoint_mid"],
+            PRESET_MODE_HIGH: self.coordinator.api._data["config"]["setpoint_high"],
         }
     
     @property

--- a/custom_components/ecostream/sensor.py
+++ b/custom_components/ecostream/sensor.py
@@ -8,7 +8,6 @@ from homeassistant.config_entries import ConfigEntry # type: ignore
 from homeassistant.core import HomeAssistant # type: ignore
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity # type: ignore
-from homeassistant.const import UnitOfTime # type: ignore
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
@@ -16,6 +15,7 @@ from homeassistant.const import (
     UnitOfTemperature,
     UnitOfTime,
     UnitOfVolumeFlowRate,
+    EntityCategory,
 )
 
 from . import EcostreamDataUpdateCoordinator
@@ -43,6 +43,10 @@ async def async_setup_entry(
         EcostreamTempOdaSensor(coordinator, entry),
         EcostreamTvocEtaSensor(coordinator, entry),
         EcostreamFilterReplacementDateSensor(coordinator, entry)
+        EcostreamWifiSSID(coordinator, entry),
+        EcostreamWifiRSSI(coordinator, entry),
+        EcostreamWifiIP(coordinator, entry),
+        EcostreamUptime(coordinator, entry),
     ]
 
     async_add_entities(sensors, update_before_add=True)
@@ -384,3 +388,91 @@ class EcostreamRhEtaSensor(EcostreamSensorBase):
     def icon(self):
         """Return the icon to use in the frontend, if any."""
         return "mdi:molecule-co2"
+
+class EcostreamWifiSSID(EcostreamSensorBase):
+    @property
+    def entity_category(self):
+        return EntityCategory.DIAGNOSTIC
+
+    @property
+    def unique_id(self):
+        return f"{self._entry_id}_wifi_ssid"
+
+    @property
+    def name(self):
+        return "Ecostream Wifi SSID"
+
+    @property
+    def state(self):
+        return self.coordinator.data["comm_wifi"]["ssid"]
+
+    @property
+    def icon(self):
+        return "mdi:wifi"
+
+class EcostreamWifiRSSI(EcostreamSensorBase):
+    @property
+    def entity_category(self):
+        return EntityCategory.DIAGNOSTIC
+
+    @property
+    def unique_id(self):
+        return f"{self._entry_id}_wifi_rssi"
+
+    @property
+    def name(self):
+        return "Ecostream Wifi RSSI"
+
+    @property
+    def state(self):
+        return int(self.coordinator.data["comm_wifi"]["rssi"])
+
+    @property
+    def icon(self):
+        return "mdi:wifi"
+
+class EcostreamWifiIP(EcostreamSensorBase):
+    @property
+    def entity_category(self):
+        return EntityCategory.DIAGNOSTIC
+
+    @property
+    def unique_id(self):
+        return f"{self._entry_id}_wifi_ip"
+
+    @property
+    def name(self):
+        return "Ecostream Wifi IP"
+
+    @property
+    def state(self):
+        return self.coordinator.data["comm_wifi"]["wifi_ip"]
+
+    @property
+    def icon(self):
+        return "mdi:network-outline"
+
+class EcostreamUptime(EcostreamSensorBase):
+    @property
+    def entity_category(self):
+        return EntityCategory.DIAGNOSTIC
+
+    @property
+    def unique_id(self):
+        return f"{self._entry_id}_uptime"
+
+    @property
+    def name(self):
+        return "Ecostream uptime"
+
+    @property
+    def state(self):
+        return self.coordinator.data["system"]["uptime"]
+
+    @property
+    def icon(self):
+        return "mdi:progress-clock"
+    
+    @property
+    def unit_of_measurement(self):
+        return UnitOfTime.SECONDS

--- a/custom_components/ecostream/sensor.py
+++ b/custom_components/ecostream/sensor.py
@@ -42,7 +42,7 @@ async def async_setup_entry(
         EcostreamTempEtaSensor(coordinator, entry),
         EcostreamTempOdaSensor(coordinator, entry),
         EcostreamTvocEtaSensor(coordinator, entry),
-        EcostreamFilterReplacementDateSensor(coordinator, entry)
+        EcostreamFilterReplacementDateSensor(coordinator, entry),
         EcostreamWifiSSID(coordinator, entry),
         EcostreamWifiRSSI(coordinator, entry),
         EcostreamWifiIP(coordinator, entry),


### PR DESCRIPTION
### Why are we changing this?
When there are connection issues, it comes in handy to read the wifi signal strength and the connected SSID

### What has changed?
- Keep track of the entire state of the ecostream and update the relevant part based on the ecostream response
- Add the wifi configuration to home assistant to aid in debugging wifi issues

<img width="270" alt="Screenshot 2025-04-01 at 21 41 45" src="https://github.com/user-attachments/assets/2ade65bd-da2b-4c54-b9ae-8591c8d08eb3" />
