### PR TITLE
Added device_class and unit_of_measurment for the RSSI sensor

### DIFF
--- a/custom_components/ecostream/sensor.py
+++ b/custom_components/ecostream/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry # type: ignore
 from homeassistant.core import HomeAssistant # type: ignore
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity # type: ignore
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
@@ -513,6 +514,14 @@ class EcostreamWifiRSSI(EcostreamSensorBase):
     @property
     def entity_category(self):
         return EntityCategory.DIAGNOSTIC
+
+    @property
+    def device_class(self):
+        return SensorDeviceClass.SIGNAL_STRENGTH
+
+    @property
+    def unit_of_measurement(self):
+        return "dBm"
 
     @property
     def unique_id(self):


### PR DESCRIPTION
Why are we changing this?
The RSSI sensor added by the previous PR added a line to the logbook each time the sensor value changed.
This seemed unneeded and it would be more usefull to see previous values in a graph.

What has changed?
Added a device_class and unit_of_measurement properties for the RSSI sensor.
This removes the entries in the logbook and instead allows you to see the history as a graph

![image](https://github.com/user-attachments/assets/28c83b7b-02c2-4a95-a3ad-aa68f19fe5a8)
