### PR TITLE
Update the state directly after a command is sent

### DIFF
--- a/custom_components/ecostream/button.py
+++ b/custom_components/ecostream/button.py
@@ -90,4 +90,4 @@ class FilterResetButton(EcostreamButtonBase):
                 "filter_datetime": nextReplacementTimestamp
             }
         }
-        await self.coordinator.api.send_json(payload)
+        await self.coordinator.send_json(payload)

--- a/custom_components/ecostream/climate.py
+++ b/custom_components/ecostream/climate.py
@@ -74,7 +74,7 @@ class EcostreamSummerComfortClimate(CoordinatorEntity, ClimateEntity):
             }
         }
 
-        await self.coordinator.api.send_json(payload)
+        await self.coordinator.send_json(payload)
     
     async def async_set_hvac_mode(self, hvac_mode):
         enable_summer_control = hvac_mode == "cool"
@@ -84,7 +84,7 @@ class EcostreamSummerComfortClimate(CoordinatorEntity, ClimateEntity):
                 "sum_com_enabled": enable_summer_control,
             }
         }
-        await self.coordinator.api.send_json(payload)
+        await self.coordinator.send_json(payload)
     
     def _current_hvac_mode(self) -> HVACMode:
         is_summer_control_enabled = self.coordinator.data["config"]["sum_com_enabled"]

--- a/custom_components/ecostream/fan.py
+++ b/custom_components/ecostream/fan.py
@@ -101,7 +101,7 @@ class EcoStreamFan(CoordinatorEntity, FanEntity):
                 "man_override_set_time": 1800
             }
         }
-        await self.coordinator.api.send_json(payload)
+        await self.coordinator.send_json(payload)
         self.current_speed = speed
         self.preset_mode = preset_mode
 

--- a/custom_components/ecostream/sensor.py
+++ b/custom_components/ecostream/sensor.py
@@ -44,6 +44,7 @@ async def async_setup_entry(
         EcostreamTempEtaSensor(coordinator, entry),
         EcostreamTempOdaSensor(coordinator, entry),
         EcostreamTvocEtaSensor(coordinator, entry),
+        EcostreamScheduledEnabledSensor(coordinator, entry),
         EcostreamSummerComfortEnabledSensor(coordinator, entry),
         EcostreamSummerComfortTemperatureSensor(coordinator, entry),
         EcostreamBypassPositionSensor(coordinator, entry),
@@ -371,6 +372,23 @@ class EcostreamTvocEtaSensor(EcostreamSensorBase):
     def icon(self):
         """Return the icon to use in the frontend, if any."""
         return "mdi:air-purifier"
+
+class EcostreamScheduledEnabledSensor(EcostreamSensorBase):
+    @property
+    def unique_id(self):
+        return f"{self._entry_id}_schedule_enabled"
+    
+    @property
+    def name(self):
+        return "Ecostream Schedule Enabled"
+
+    @property
+    def state(self):
+        return self.coordinator.data["config"]["schedule_enabled"]
+
+    @property
+    def icon(self):
+        return "mdi:toggle-switch-variant" if self.state else "mdi:toggle-switch-variant-off"
 
 class EcostreamSummerComfortEnabledSensor(EcostreamSensorBase):
     @property

--- a/custom_components/ecostream/switch.py
+++ b/custom_components/ecostream/switch.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.config_entries import ConfigEntry 
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import EcostreamDataUpdateCoordinator, EcostreamWebsocketsAPI
+from .const import DOMAIN
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry[EcostreamDataUpdateCoordinator],
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = entry.runtime_data
+    
+    buttons = [
+        ScheduleSwitch(coordinator, entry)
+    ]
+
+    async_add_entities(buttons)
+
+class EcostreamSwitchBase(CoordinatorEntity, SwitchEntity):
+    def __init__(self, coordinator: EcostreamDataUpdateCoordinator, entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._entry_id = entry.entry_id
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.api._host)},
+            name="EcoStream",
+            manufacturer="Buva",
+            model="EcoStream",
+        )
+
+class ScheduleSwitch(EcostreamSwitchBase):
+    def __init__(self, coordinator: EcostreamDataUpdateCoordinator, entry: ConfigEntry):
+        super().__init__(coordinator, entry)
+
+    @property
+    def unique_id(self):
+        return f"{self._entry_id}_schedule_switch"
+
+    @property
+    def name(self):
+        return "Schedule"
+
+    @property
+    def icon(self):
+        return "mdi:calendar-month-outline"
+    
+    @callback
+    def _handle_coordinator_update(self):
+        self._attr_is_on = self.coordinator.data["config"]["schedule_enabled"]
+        self.async_write_ha_state()
+    
+    async def async_turn_on(self):
+        await self._change_schedule(True)
+
+    async def async_turn_off(self):
+        await self._change_schedule(False)
+    
+    async def _change_schedule(self, schedule_enabled: bool):
+        payload = {
+            "config": {
+                "schedule_enabled": schedule_enabled
+            }
+        }
+        await self.coordinator.send_json(payload)

--- a/custom_components/ecostream/valve.py
+++ b/custom_components/ecostream/valve.py
@@ -93,7 +93,7 @@ class EcostreamBypassValve(CoordinatorEntity, ValveEntity):
         if config["man_override_bypass_time"] > 0:
             target = config["man_override_bypass"]
 
-            if abs(self._attr_current_valve_position - target) < 0.01:
+            if abs(self._attr_current_valve_position - target) < 0.1:
                 # The difference is more likely due to rounding issues. Don't report a current action.
                 pass
             elif self._attr_current_valve_position > target:


### PR DESCRIPTION
### Why are we changing this?
The home assistant interface does not always update immediately after executing an action. This is caused by the polling interval of the integration.

### What has changed?
- After a command is sent, update the state immediately to persist the response of the ecostream on the action. On top of that schedule a slightly delayed update that ensures the entire state of the integration is updated before the polling interval.
- Add a sensor that shows if the schedule is activated or not
- Add a switch that controls if the schedule is activated
- Add closing/opening state to the bypass valve. This is necessary because the value is not immediately opened/closes and it seems like the interface is lacking. 

<img width="263" alt="Screenshot 2025-04-21 at 22 09 13" src="https://github.com/user-attachments/assets/d41633f1-406e-4443-8406-2d045235242e" />
