### PR TITLE
Enabled LongTermStatistics

### DIFF
--- a/custom_components/ecostream/sensor.py
+++ b/custom_components/ecostream/sensor.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry # type: ignore
 from homeassistant.core import HomeAssistant # type: ignore
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity # type: ignore
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity,SensorStateClass
 from homeassistant.const import (
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
@@ -59,7 +59,7 @@ async def async_setup_entry(
 
     async_add_entities(sensors, update_before_add=True)
 
-class EcostreamSensorBase(CoordinatorEntity, Entity):
+class EcostreamSensorBase(CoordinatorEntity, SensorEntity):
     """Base class for ecostream sensors."""
 
     def __init__(self, coordinator: EcostreamDataUpdateCoordinator, entry: ConfigEntry):
@@ -96,6 +96,10 @@ class EcostreamFrostProtectionSensor(EcostreamSensorBase):
     @property
     def state(self):
         return self.coordinator.data.get("status", {}).get("frost_protection")
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
@@ -180,6 +184,10 @@ class EcostreamQsetSensor(EcostreamSensorBase):
         return self.coordinator.data.get("status", {}).get("qset")
     
     @property
+    def device_class(self):
+        return SensorDeviceClass.VOLUME_FLOW_RATE
+
+    @property
     def unit_of_measurement(self):
         return UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR
 
@@ -229,6 +237,11 @@ class EcostreamFanEHASpeed(EcostreamSensorBase):
     @property
     def unit_of_measurement(self):
         return REVOLUTIONS_PER_MINUTE
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
+
     
 class EcostreamFanSUPSpeed(EcostreamSensorBase):
 
@@ -253,6 +266,10 @@ class EcostreamFanSUPSpeed(EcostreamSensorBase):
     def unit_of_measurement(self):
         return REVOLUTIONS_PER_MINUTE
 
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
+
 class EcostreamEco2EtaSensor(EcostreamSensorBase):
     """Sensor for eCO2 Return."""
 
@@ -269,8 +286,16 @@ class EcostreamEco2EtaSensor(EcostreamSensorBase):
         return self.coordinator.data.get("status", {}).get("sensor_eco2_eta")
 
     @property
+    def device_class(self):
+        return SensorDeviceClass.CO2
+
+    @property
     def unit_of_measurement(self):
         return CONCENTRATION_PARTS_PER_MILLION
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
@@ -293,8 +318,16 @@ class EcostreamTempEhaSensor(EcostreamSensorBase):
         return self.coordinator.data.get("status", {}).get("sensor_temp_eha")
 
     @property
+    def device_class(self):
+        return SensorDeviceClass.TEMPERATURE
+
+    @property
     def unit_of_measurement(self):
         return UnitOfTemperature.CELSIUS
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
@@ -316,9 +349,17 @@ class EcostreamTempEtaSensor(EcostreamSensorBase):
     def state(self):
         return self.coordinator.data.get("status", {}).get("sensor_temp_eta")
 
+    @property   
+    def device_class(self):
+        return SensorDeviceClass.TEMPERATURE
+
     @property
     def unit_of_measurement(self):
         return UnitOfTemperature.CELSIUS
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
@@ -340,9 +381,17 @@ class EcostreamTempOdaSensor(EcostreamSensorBase):
     def state(self):
         return self.coordinator.data.get("status", {}).get("sensor_temp_oda")
 
+    @property   
+    def device_class(self):
+        return SensorDeviceClass.TEMPERATURE
+
     @property
     def unit_of_measurement(self):
         return UnitOfTemperature.CELSIUS
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
@@ -364,9 +413,17 @@ class EcostreamTvocEtaSensor(EcostreamSensorBase):
     def state(self):
         return self.coordinator.data.get("status", {}).get("sensor_tvoc_eta")
 
+    @property   
+    def device_class(self):
+        return SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS
+
     @property
     def unit_of_measurement(self):
         return CONCENTRATION_PARTS_PER_BILLION
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
@@ -420,9 +477,17 @@ class EcostreamSummerComfortTemperatureSensor(EcostreamSensorBase):
     def state(self):
         return self.coordinator.data["config"]["sum_com_temp"]
     
+    @property   
+    def device_class(self):
+        return SensorDeviceClass.TEMPERATURE
+
     @property
     def unit_of_measurement(self):
         return UnitOfTemperature.CELSIUS
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
@@ -445,6 +510,10 @@ class EcostreamBypassPositionSensor(EcostreamSensorBase):
     def unit_of_measurement(self):
         return PERCENTAGE
 
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
+
 class EcostreamBypassOverridePosition(EcostreamSensorBase):
     @property
     def unique_id(self):
@@ -461,6 +530,10 @@ class EcostreamBypassOverridePosition(EcostreamSensorBase):
     @property
     def unit_of_measurement(self):
         return PERCENTAGE
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
 
 class EcostreamBypassOverrideTimeLeftSensor(EcostreamSensorBase):
     @property
@@ -498,9 +571,17 @@ class EcostreamRhEtaSensor(EcostreamSensorBase):
     def state(self):
         return self.coordinator.data.get("status", {}).get("sensor_rh_eta")
 
+    @property   
+    def device_class(self):
+        return SensorDeviceClass.HUMIDITY
+
     @property
     def unit_of_measurement(self):
-        return "%"
+        return PERCENTAGE
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
 
     @property
     def icon(self):
@@ -540,6 +621,10 @@ class EcostreamWifiRSSI(EcostreamSensorBase):
     @property
     def unit_of_measurement(self):
         return "dBm"
+
+    @property
+    def state_class(self) -> SensorStateClass:
+        return SensorStateClass.MEASUREMENT
 
     @property
     def unique_id(self):


### PR DESCRIPTION
I noticed that data was only stored for 10 days (default setting of the [Recorder](https://www.home-assistant.io/integrations/recorder/)).

I added a stateclass property for the sensors where i thought it would make sense to store the data for longer period (see [Long Term Statistics](https://data.home-assistant.io/docs/statistics/))
As a results these entities now show min/mean/max statistics in 5 minute increments in their history chart and older data gets downsampled to an average per hour and is stored indefinitely, not tested yet is I made the changes only recently.
But the correct state_class is shown in the developers->states view so it should work.

![image](https://github.com/user-attachments/assets/f8442df4-db52-45ee-94e8-8649b5d6032a)

![image](https://github.com/user-attachments/assets/5b25911c-7753-4aa5-bd37-799f6ce0985a)
