### PR TITLE
Refactor Ecostream integration for better connection logic

### DIFF
--- a/custom_components/ecostream/__init__.py
+++ b/custom_components/ecostream/__init__.py
@@ -198,6 +198,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = EcostreamDataUpdateCoordinator(hass, api)
     await coordinator.async_config_entry_first_refresh()
 
+    # Set unique device ID to prevent rediscovery duplicates
+    device_name = api._data.get("system", {}).get("system_name")
+    if device_name and entry.unique_id is None:
+        hass.config_entries.async_update_entry(entry, unique_id=device_name)    
+
     hass.data[DOMAIN][entry.entry_id] = api
     hass.data[DOMAIN]["ws_client"] = api
     entry.runtime_data = coordinator

--- a/custom_components/ecostream/__init__.py
+++ b/custom_components/ecostream/__init__.py
@@ -1,9 +1,9 @@
-"""The ecostream integration (stable version with reconnect logic)."""
+"""Ecostream integration (no pings, with application-level heartbeat)."""
 
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
+from datetime import timedelta, datetime
 import json
 import logging
 import websockets  # type: ignore
@@ -17,6 +17,8 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+CONF_STALE_TIMEOUT = "stale_timeout"
+
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.FAN,
@@ -28,43 +30,53 @@ PLATFORMS: list[Platform] = [
 
 
 class EcostreamWebsocketsAPI:
-    """Handle a persistent connection to an Ecostream websocket."""
+    """Maintain a persistent WebSocket connection to an Ecostream device."""
 
-    def __init__(self) -> None:
+    def __init__(self, stale_timeout: int = 300) -> None:
         self.connection: websockets.WebSocketClientProtocol | None = None
         self._host: str | None = None
         self._data: dict = {}
         self._device_name: str | None = None
         self._listen_task: asyncio.Task | None = None
+        self._watchdog_task: asyncio.Task | None = None
+        self._heartbeat_task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
+        self._last_message_time: datetime | None = None
+        self._stale_timeout = stale_timeout
 
     async def connect(self, host: str):
-        """Establish a websocket connection and start listener."""
+        """Establish a websocket connection and start background tasks."""
         self._host = host
         await self._connect_once()
         self._listen_task = asyncio.create_task(self._listen())
+        self._watchdog_task = asyncio.create_task(self._watchdog())
+        self._heartbeat_task = asyncio.create_task(self._heartbeat())
 
     async def _connect_once(self):
-        """Perform one connection attempt."""
+        """Perform one connection attempt without protocol-level pings."""
         _LOGGER.debug("Connecting to Ecostream at ws://%s", self._host)
-        self.connection = await websockets.connect(f"ws://{self._host}")
+        self.connection = await websockets.connect(
+            f"ws://{self._host}",
+            ping_interval=None,   # disable protocol-level pings
+            ping_timeout=None,
+        )
         _LOGGER.info("Connected to Ecostream at %s", self._host)
+        self._last_message_time = datetime.utcnow()
 
     async def _listen(self):
-        """Background listener loop."""
+        """Continuously receive and process messages from the device."""
         while not self._stop_event.is_set():
             if not self.connection:
                 await asyncio.sleep(2)
                 continue
-
             try:
                 msg = await self.connection.recv()
                 parsed = json.loads(msg)
+                self._last_message_time = datetime.utcnow()
 
                 for key in ["comm_wifi", "system", "config", "status"]:
                     self._data[key] = self._data.get(key, {}) | parsed.get(key, {})
 
-                # Capture device name if present
                 if "system" in parsed and "system_name" in parsed["system"]:
                     self._device_name = parsed["system"]["system_name"]
 
@@ -75,27 +87,54 @@ class EcostreamWebsocketsAPI:
                 _LOGGER.error("Websocket listener error: %s", e)
                 await asyncio.sleep(5)
 
-    async def _reconnect_loop(self):
-        """Try reconnecting with exponential backoff."""
-        delay = 2
-        for attempt in range(1, 6):
+    async def _heartbeat(self):
+        """Send a small heartbeat message every 20 s so the device sees activity."""
+        while not self._stop_event.is_set():
+            await asyncio.sleep(20)
             try:
-                _LOGGER.info("Reconnect attempt %d to %s", attempt, self._host)
+                if self.connection:
+                    await self.connection.send("{}")
+                    _LOGGER.debug("Heartbeat sent")
+            except Exception:
+                _LOGGER.debug("Heartbeat failed, will rely on reconnect loop")
+
+    async def _watchdog(self):
+        """Force reconnect if no messages are received for longer than stale_timeout."""
+        while not self._stop_event.is_set():
+            await asyncio.sleep(60)
+            if not self._last_message_time:
+                continue
+            elapsed = (datetime.utcnow() - self._last_message_time).total_seconds()
+            if elapsed > self._stale_timeout:
+                _LOGGER.warning(
+                    "No data received for %d s (>%d) — forcing reconnect",
+                    int(elapsed),
+                    self._stale_timeout,
+                )
+                await self._reconnect_loop()
+
+    async def _reconnect_loop(self):
+        """Try reconnecting with exponential backoff (starting at 10 s)."""
+        delay = 10
+        for attempt in range(1, 6):
+            if self._stop_event.is_set():
+                return
+            try:
+                _LOGGER.info("Reconnect attempt %d to %s (waiting %ds)", attempt, self._host, delay)
+                await asyncio.sleep(delay)
                 await self._connect_once()
                 _LOGGER.info("Reconnected successfully.")
                 return
             except Exception as e:
                 _LOGGER.warning("Reconnect attempt %d failed: %s", attempt, e)
-                await asyncio.sleep(delay)
                 delay = min(delay * 2, 60)
-        _LOGGER.error("Failed to reconnect after multiple attempts; will keep retrying in background.")
+        _LOGGER.error("Failed to reconnect after multiple attempts; will retry later.")
 
     async def send_json(self, payload: dict):
-        """Send a JSON payload through the WebSocket."""
+        """Send a JSON payload to the WebSocket."""
         if not self.connection:
             _LOGGER.warning("No active connection, attempting reconnect before sending.")
             await self._reconnect_loop()
-
         try:
             await self.connection.send(json.dumps(payload))
         except websockets.ConnectionClosed:
@@ -107,19 +146,20 @@ class EcostreamWebsocketsAPI:
             _LOGGER.error("Failed to send data: %s", e)
 
     async def get_data(self):
-        """Return the last known data (non-blocking)."""
+        """Return the latest known data (non-blocking)."""
         return self._data
 
     async def close(self):
-        """Close connection and stop background task."""
+        """Cleanly close the connection and stop background tasks."""
         _LOGGER.debug("Closing Ecostream websocket connection.")
         self._stop_event.set()
-        if self._listen_task:
-            self._listen_task.cancel()
-            try:
-                await self._listen_task
-            except asyncio.CancelledError:
-                pass
+        for task in (self._listen_task, self._watchdog_task, self._heartbeat_task):
+            if task:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
         if self.connection:
             await self.connection.close()
             self.connection = None
@@ -134,18 +174,16 @@ class EcostreamDataUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=120),  # Only occasional refresh
+            update_interval=timedelta(seconds=120),
         )
 
     async def _async_update_data(self):
-        """Fetch current cached data from the websocket API."""
+        """Fetch current cached data from the WebSocket API."""
         return await self.api.get_data()
 
     async def send_json(self, payload: dict):
         await self.api.send_json(payload)
-        # Immediate refresh to reflect the direct response
         await self.async_refresh()
-        # Schedule a short delayed refresh for slower actions
         await self.async_request_refresh()
 
 
@@ -153,7 +191,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Ecostream integration."""
     hass.data.setdefault(DOMAIN, {})
 
-    api = EcostreamWebsocketsAPI()
+    stale_timeout = entry.options.get(CONF_STALE_TIMEOUT, 300)
+    api = EcostreamWebsocketsAPI(stale_timeout=stale_timeout)
     await api.connect(entry.data[CONF_HOST])
 
     coordinator = EcostreamDataUpdateCoordinator(hass, api)
@@ -164,7 +203,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    _LOGGER.info("Ecostream integration setup complete for host %s", entry.data[CONF_HOST])
+    _LOGGER.info(
+        "Ecostream integration setup complete for host %s "
+        "(stale_timeout=%ds, heartbeat=20s, pings disabled)",
+        entry.data[CONF_HOST],
+        stale_timeout,
+    )
     return True
 
 

--- a/custom_components/ecostream/config_flow.py
+++ b/custom_components/ecostream/config_flow.py
@@ -1,109 +1,68 @@
-"""Config flow for ecostream integration."""
 from __future__ import annotations
 
-import logging
-from typing import Any, Optional
-import voluptuous as vol # type: ignore
-
-from homeassistant import config_entries # type: ignore
-from homeassistant.core import HomeAssistant # type: ignore
-from homeassistant.data_entry_flow import FlowResult # type: ignore
+import voluptuous as vol
+from homeassistant import config_entries
 from homeassistant.const import CONF_HOST
-from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo # type: ignore
+from homeassistant.data_entry_flow import FlowResult
 
-from .const import DOMAIN  # Import your domain name from const.py
-from .__init__ import EcostreamWebsocketsAPI  # Import the API class
+from .const import DOMAIN
 
-LOGGER = logging.getLogger(__name__)
-
-# Define the configuration schema
-STEP_USER_DATA_SCHEMA = vol.Schema({
-    vol.Required(CONF_HOST): str,
-})
 
 class EcostreamConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for ecostream."""
+    """Handle the config flow for Ecostream."""
 
     VERSION = 1
 
     async def async_step_user(self, user_input=None) -> FlowResult:
-        """Handle the initial step."""
+        """Handle manual configuration."""
         errors = {}
 
         if user_input is not None:
             host = user_input[CONF_HOST]
 
-            # Validate the WebSocket connection
-            api = await self._test_connection(host)
-            valid = api is not None
+            # If device already configured → abort
+            await self.async_set_unique_id(host)
+            self._abort_if_unique_id_configured()
 
-            if valid:
-                # Create a config entry if the connection is valid
-                return self.async_create_entry(title=api._device_name, data=user_input)
-            else:
-                errors["base"] = "cannot_connect"
+            return self.async_create_entry(title=f"Ecostream ({host})", data={CONF_HOST: host})
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
+            errors=errors,
         )
 
-    async def async_step_zeroconf(
-        self, discovery_info: ZeroconfServiceInfo
-    ) -> config_entries.ConfigFlowResult:
-        """Handle zeroconf discovery."""
-        self.host = f"{discovery_info.host}:{discovery_info.port}"
-        LOGGER.debug("Discovered device: %s", self.host)
+    async def async_step_zeroconf(self, discovery_info) -> FlowResult:
+        """Handle automatic discovery via Zeroconf / mDNS."""
+        host = discovery_info.get("host")
 
-        self.api = await self._test_connection(self.host)
+        # Use host as temporary unique_id (will be replaced by system_name later)
+        await self.async_set_unique_id(host)
+        self._abort_if_unique_id_configured()
 
-        if self.api is None: 
-            return self.async_abort(reason="cannot_connect")
-
-        await self.async_set_unique_id(self.api._device_name)
-
-        self._abort_if_unique_id_configured(
-            updates={CONF_HOST: self.host},
-            error="already_configured_device",
+        # Suggest configuration flow to the user instead of auto-adding
+        return self.async_show_form(
+            step_id="user",
+            description_placeholders={"host": host},
+            data_schema=vol.Schema({vol.Required(CONF_HOST, default=host): str}),
         )
 
-        self.context.update(
-            {
-                "title_placeholders": {
-                    "name": self.api._device_name,
-                },
-            }
+    async def async_step_ssdp(self, discovery_info) -> FlowResult:
+        """Handle SSDP discovery (if present)."""
+        host = discovery_info.get("host")
+
+        await self.async_set_unique_id(host)
+        self._abort_if_unique_id_configured()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_HOST, default=host): str}),
         )
-            
-        return await self.async_step_discovery_confirm()
 
-    async def async_step_discovery_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.ConfigFlowResult:
-        """Confirm discovery."""
-        if user_input is not None:
-            return self.async_create_entry(
-                title=self.api._device_name,
-                data={CONF_HOST: self.host},
-            )
-
-        self._set_confirm_only()
-
-        return self.async_show_form(step_id="discovery_confirm")
-
-    async def _test_connection(self, host: str) -> Optional[EcostreamWebsocketsAPI]:
-        """Test the WebSocket connection to the specified host."""
-        try:
-            api = EcostreamWebsocketsAPI()
-            await api.connect(host)
-            await api.get_data()  # Attempt to fetch data to confirm the connection works
-            return api
-        except Exception as e:
-            LOGGER.error("Failed to connect to %s: %s", host, e)
-            return None
-
-    async def async_step_reauth(self, data: dict) -> FlowResult:
-        """Handle re-authentication."""
-        self.context["title_placeholders"] = {
-            CONF_HOST: data[CONF_HOST],
-        }
-        return await self.async_step_user(user_input=data)
+    async def async_step_reconfigure(self, entry_data) -> FlowResult:
+        """Allow reconfiguration if needed."""
+        host = entry_data.get(CONF_HOST)
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({vol.Required(CONF_HOST, default=host): str}),
+        )


### PR DESCRIPTION
**Problem | Solution**
recv() was blocking during polling | Added a persistent background listener (_listen)
No reconnect retry mechanism | Implemented exponential backoff up to 60 seconds
Old connection remained open | close() now properly closes the socket and cancels the background task
get_data() could block | Now returns only cached data (non-blocking)
Unnecessarily high polling frequency | Increased coordinator interval to 120 seconds
No logging during recovery | Added clear log messages for connect/disconnect/reconnect events

