### PR TITLE
Re-added missing icons for fan presets

### DIFF
--- a/custom_components/ecostream/fan.py
+++ b/custom_components/ecostream/fan.py
@@ -79,6 +79,7 @@ class EcostreamVentilationFan(  # type: ignore[misc]
     _attr_name = "Ventilation"
     _attr_should_poll = False
     _attr_icon = "mdi:fan"
+    _attr_translation_key = "ventilation"
     coordinator: EcostreamDataUpdateCoordinator
 
     def __init__(

--- a/custom_components/ecostream/icons.json
+++ b/custom_components/ecostream/icons.json
@@ -1,0 +1,18 @@
+{
+  "entity": {
+    "fan": {
+      "ventilation": {
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:fan",
+            "state": {
+              "low": "mdi:fan-speed-1",
+              "mid": "mdi:fan-speed-2",
+              "high": "mdi:fan-speed-3"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
After I updated to v2.2 the icons for the preset fan speeds were gone.
This PR adds them back in.

Before:
<img width="494" height="120" alt="image" src="https://github.com/user-attachments/assets/1bff2021-ff53-42fb-97ff-bb57710ceacb" />

After:
<img width="487" height="115" alt="image" src="https://github.com/user-attachments/assets/1109b1ea-2fc2-41f5-986d-ca74662df0ab" />