### PR TITLE
Stop resetting filter_datetime on every options save

### DIFF
--- a/custom_components/ecostream/__init__.py
+++ b/custom_components/ecostream/__init__.py
@@ -10,13 +10,11 @@ from homeassistant.helpers.device_registry import (
     async_get as async_get_device_registry,
 )
 import logging
-import time
 from typing import Any
 
 from aiohttp import ClientError, WSMsgType
 
 from .const import (
-    CONF_ALLOW_OVERRIDE_FILTER_DATE,
     CONF_BOOST_DURATION,
     CONF_FILTER_REPLACEMENT_DAYS,
     CONF_PRESET_OVERRIDE_MINUTES,
@@ -145,7 +143,6 @@ async def _async_options_updated(
     """Update device configuration when options change."""
     coordinator: EcostreamDataUpdateCoordinator = entry.runtime_data
 
-    # Update boost duration
     boost_duration = int(
         entry.options.get(
             CONF_BOOST_DURATION, DEFAULT_BOOST_DURATION_MINUTES
@@ -153,41 +150,10 @@ async def _async_options_updated(
     )
     coordinator.boost_duration_minutes = boost_duration
 
-    # Only update filter date if override is allowed
-    allow_override = entry.options.get(
-        CONF_ALLOW_OVERRIDE_FILTER_DATE, False
+    _LOGGER.debug(
+        "EcoStream options updated: boost_duration=%sm",
+        boost_duration,
     )
-
-    if allow_override:
-        if not coordinator.ws:
-            _LOGGER.debug(
-                "EcoStream options updated locally (boost_duration=%sm), skipping filter_datetime update because WS is disconnected",
-                boost_duration,
-            )
-            return
-
-        filter_days = int(
-            entry.options.get(
-                CONF_FILTER_REPLACEMENT_DAYS,
-                DEFAULT_FILTER_REPLACEMENT_DAYS,
-            )
-        )
-        filter_datetime = int(time.time() + filter_days * 86400)
-
-        await coordinator.ws.send_json(
-            {"config": {"filter_datetime": filter_datetime}}
-        )
-        _LOGGER.debug(
-            "EcoStream filter_datetime updated: %s days → timestamp %s, boost_duration=%sm",
-            filter_days,
-            filter_datetime,
-            boost_duration,
-        )
-    else:
-        _LOGGER.debug(
-            "EcoStream options updated: boost_duration=%sm (filter override disabled)",
-            boost_duration,
-        )
 
 
 async def async_unload_entry(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -351,8 +351,8 @@ async def test_cleanup_stale_devices_keeps_current_host():
 
 
 @pytest.mark.asyncio
-async def test_options_updated_with_filter_override_enabled():
-    """Test options update when filter override is enabled."""
+async def test_options_updated_sets_boost_duration():
+    """Test options update sets boost_duration_minutes and never touches filter_datetime."""
 
     hass = MagicMock()
     entry = MagicMock()
@@ -367,40 +367,9 @@ async def test_options_updated_with_filter_override_enabled():
     coordinator.ws.send_json = AsyncMock()
     entry.runtime_data = coordinator
 
-    with patch(
-        "custom_components.ecostream.time.time", return_value=1000
-    ):
-        await async_options_updated(hass, entry)
-
-    assert coordinator.boost_duration_minutes == 30
-    coordinator.ws.send_json.assert_called_once()
-    call_args = coordinator.ws.send_json.call_args[0][0]
-    assert "config" in call_args
-    assert "filter_datetime" in call_args["config"]
-    expected_timestamp = 1000 + (90 * 86400)
-    assert call_args["config"]["filter_datetime"] == expected_timestamp
-
-
-@pytest.mark.asyncio
-async def test_options_updated_with_filter_override_disabled():
-    """Test options update when filter override is disabled."""
-
-    hass = MagicMock()
-    entry = MagicMock()
-    entry.options = {
-        "boost_duration": 15,
-        "allow_override_filter_date": False,
-    }
-
-    coordinator = MagicMock()
-    coordinator.ws = MagicMock()
-    coordinator.ws.send_json = AsyncMock()
-    entry.runtime_data = coordinator
-
     await async_options_updated(hass, entry)
 
-    assert coordinator.boost_duration_minutes == 15
-    # Should not send JSON when override is disabled
+    assert coordinator.boost_duration_minutes == 30
     coordinator.ws.send_json.assert_not_called()
 
 
@@ -423,7 +392,6 @@ async def test_options_updated_with_ws_disconnected():
     await async_options_updated(hass, entry)
 
     assert coordinator.boost_duration_minutes == 20
-    # No exception should be raised
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
_async_options_updated was pushing a new filter_datetime to the device whenever allow_override_filter_date was enabled, meaning any settings change (e.g. adjusting boost duration) would silently reset the filter replacement date. The filter date should only be updated by the dedicated reset filter button.